### PR TITLE
CORE-2569: Initialize croppie only once

### DIFF
--- a/angular-croppie.js
+++ b/angular-croppie.js
@@ -23,13 +23,6 @@ angular.module('ovi.croppie', []).
         options.result
       );
 
-      function resetCroppie(){
-        'use strict';
-          angular.element($element[0]).empty();
-        return new Croppie($element[0], options);
-      }
-
-      var c = resetCroppie();
       options.update = function () {
         c.result(resultOptions).then(function(img) {
           $scope.$apply(function () {
@@ -38,13 +31,14 @@ angular.module('ovi.croppie', []).
         });
       };
 
+      var c = new Croppie($element[0], options);
+
       $scope.$watch(function(){
         return ctrl.src;
       }, function (newSrc) {
 
         if(!ctrl.src) { return; }
         // bind an image to croppie
-        c = resetCroppie();
         c.bind({ url: newSrc, zoom: 0 });
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-croppie",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Use Croppie (https://github.com/Foliotek/Croppie) for a simple image cropping.",
   "main": "angular-croppie.js",
   "scripts": {


### PR DESCRIPTION
We got error in upload coach profile photo page saying: "Can't initialize croppie more than once"
Tried out locally with `"angular-croppie": "file:angular-croppie-1.0.5.tgz"` and it works. 

I would need help in order to release the new version "1.0.5". I saw some tags here but no .github action etc.

Jira: https://oviva-ag.atlassian.net/browse/CORE-2569