### PR TITLE
CORE-4673: use inject to explicitly set annotations

### DIFF
--- a/angular-croppie.js
+++ b/angular-croppie.js
@@ -8,38 +8,43 @@ angular.module('ovi.croppie', []).
       ngModel: '=',
       options: '<'
     },
-    controller: function ($scope, $element) {
-      var ctrl = this;
-
-      var options = angular.extend({
-        viewport: {
-          width: 200,
-          height: 200
-        }
-      }, ctrl.options);
-
-      var resultOptions = angular.extend(
-        {type:'canvas', format:'jpeg'},
-        options.result
-      );
-
-      options.update = function () {
-        c.result(resultOptions).then(function(img) {
-          $scope.$apply(function () {
-            ctrl.ngModel = img;
-          });
-        });
-      };
-
-      var c = new Croppie($element[0], options);
-
-      $scope.$watch(function(){
-        return ctrl.src;
-      }, function (newSrc) {
-
-        if(!ctrl.src) { return; }
-        // bind an image to croppie
-        c.bind({ url: newSrc, zoom: 0 });
-      });
-    }
+    controller: Controller
   });
+
+
+function Controller($scope, $element) {
+  var ctrl = this;
+  
+  var options = angular.extend({
+    viewport: {
+      width: 200,
+      height: 200
+    }
+  }, ctrl.options);
+  
+  var resultOptions = angular.extend(
+    {type:'canvas', format:'jpeg'},
+    options.result
+  );
+  
+  options.update = function () {
+    c.result(resultOptions).then(function(img) {
+      $scope.$apply(function () {
+        ctrl.ngModel = img;
+      });
+    });
+  };
+  
+  var c = new Croppie($element[0], options);
+  
+  $scope.$watch(function(){
+    return ctrl.src;
+  }, function (newSrc) {
+    
+    if(!ctrl.src) { return; }
+    // bind an image to croppie
+    c.bind({ url: newSrc, zoom: 0 });
+  });
+}
+
+Controller.$inject = ['$scope', '$element'];


### PR DESCRIPTION
see https://docs.angularjs.org/api/ng/directive/ngApp\#with-ngstrictdi-

Issue: we have `strictDi` set in our angular app, which requires explicit setting of used annotations.
Error: `Error: [$injector:strictdi] controller is not using explicit annotation and cannot be invoked in strict mode`

Alternative solution is to disable strict mode: https://github.com/oviva-ag/ocs_frontend/blob/72673e199d08ce28a59f5615040d6eca37d743c0/ocs_v2/src/app/index.bootstrap.js#L56